### PR TITLE
Adding fix of 22feb2022 to the Glicko-2 algorithm

### DIFF
--- a/lib/exglicko2/rating.ex
+++ b/lib/exglicko2/rating.ex
@@ -154,7 +154,7 @@ defmodule Exglicko2.Rating do
         end
       )
       |> Stream.drop_while(fn {a, b, _f_a, _f_b} ->
-        abs(b - a) > @convergence_tolerance
+        abs(b - a) >= @convergence_tolerance
       end)
       |> Enum.at(0)
       |> elem(0)


### PR DESCRIPTION
As mentioned on the http://glicko.net/glicko.html website :

"
NOTE: As of February 22, 2012 the Glicko-2 iterative procedure ("Step 5") has been corrected and is now stable. Please see the Glicko-2 rating system document for details.

This document has been revised on March 22, 2022, to replace a "<" with "<=" in item 4(b) of Step 5 (page 3). 
"